### PR TITLE
Add Xbox360 support through new USBBackend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ crashlytics-build.properties
 
 # Package cache
 Packages/packages-lock.json
+
+# For the macos folks!
+.DS_Store

--- a/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB.meta
+++ b/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 619d73f1b65c541cdbb8efd15a717522
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/LibUSBWrapper.cs
+++ b/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/LibUSBWrapper.cs
@@ -61,6 +61,9 @@ namespace HIDrogen.Imports {
         public static extern void libusb_exit(IntPtr handle);
 
         [DllImport(LIBUSB_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void libusb_set_auto_detach_kernel_driver(IntPtr device_handle, int enable);
+
+        [DllImport(LIBUSB_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
         public static extern LibUSBError libusb_claim_interface(IntPtr device_handle, int interface_number);
 
         [DllImport(LIBUSB_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
@@ -187,6 +190,9 @@ namespace HIDrogen.Imports {
             {
                 Logging.Error($"Failed to open USB device: {Imports.ErrorToString(result)} (0x{(int)result:X8})");
             }
+
+            // Automatically detach/re-attach any kernel drivers that might be using this device. (linux only)
+            Imports.libusb_set_auto_detach_kernel_driver(_handle, 1);
         }
 
         public void ClaimInterface(int interfaceIndex)

--- a/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/LibUSBWrapper.cs
+++ b/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/LibUSBWrapper.cs
@@ -6,7 +6,7 @@ namespace HIDrogen.Imports {
 
     // Define the device descriptor structure
     [StructLayout(LayoutKind.Sequential)]
-    internal struct LibUSBDeviceDescriptor
+    public struct LibUSBDeviceDescriptor
     {
         public byte bLength;
         public byte bDescriptorType;
@@ -150,18 +150,11 @@ namespace HIDrogen.Imports {
     internal class LibUSBDevice : IDisposable
     {
         private readonly IntPtr _devicePointer;
-        private readonly LibUSBDeviceDescriptor _descriptor;
+        private LibUSBDeviceDescriptor _descriptor;
         private IntPtr _handle = IntPtr.Zero;
 
         public LibUSBDevice(IntPtr devicePointer)
         {
-            // Populate the device descriptor.
-            var result = Imports.libusb_get_device_descriptor(devicePointer, ref _descriptor);
-            if (result != 0)
-            {
-                Logging.Error($"Failed to retrieve USB device descriptor: {Imports.ErrorToString(result)} (0x{result:X8})");
-            }
-
             _devicePointer = devicePointer;
         }
 
@@ -174,11 +167,16 @@ namespace HIDrogen.Imports {
         // between libusb_get_device_list calls.
         public int Id => (int)_devicePointer;
 
-        // Get the Vendor ID
-        public ushort VendorID => _descriptor.idVendor;
+        public LibUSBDeviceDescriptor GetDescriptor()
+        {
+            var result = Imports.libusb_get_device_descriptor(_devicePointer, ref _descriptor);
+            if (result != 0)
+            {
+                Logging.Error($"Failed to retrieve USB device descriptor: {Imports.ErrorToString(result)} (0x{result:X8})");
+            }
 
-        // Get the Product ID
-        public ushort ProductID => _descriptor.idProduct;
+            return _descriptor;
+        }
 
         // Open the device
         public void Open()

--- a/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/LibUSBWrapper.cs
+++ b/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/LibUSBWrapper.cs
@@ -170,6 +170,10 @@ namespace HIDrogen.Imports {
             Dispose();
         }
 
+        // The pointer can serve as a unique ID, persisting
+        // between libusb_get_device_list calls.
+        public int Id => (int)_devicePointer;
+
         // Get the Vendor ID
         public ushort VendorID => _descriptor.idVendor;
 

--- a/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/LibUSBWrapper.cs
+++ b/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/LibUSBWrapper.cs
@@ -1,0 +1,216 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Runtime.InteropServices;
+using UnityEngine;
+
+namespace LibUSBWrapper {
+
+    public static class Global
+    {
+        // Ensure this DLL is available in /Assets/Plugins.
+        public const string LIBUSB_LIBRARY = "libusb-1.0.0";
+    }
+
+    public class LibUSB : IDisposable
+    {
+        // P/Invoke declarations
+        [DllImport(Global.LIBUSB_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int libusb_init(ref IntPtr handle);
+
+        [DllImport(Global.LIBUSB_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int libusb_get_device_list(IntPtr ctx, ref IntPtr list);
+
+        [DllImport(Global.LIBUSB_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
+        private static extern void libusb_free_device_list(IntPtr list, int unref_devices);
+
+        [DllImport(Global.LIBUSB_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
+        private static extern void libusb_exit(IntPtr handle);
+
+        private IntPtr _context = IntPtr.Zero;
+        private IntPtr _deviceList = IntPtr.Zero;
+
+        public LibUSB()
+        {
+            int result = libusb_init(ref _context);
+            if (result < 0)
+            {
+                throw new Exception("[LibUSB] Failed to initialize, error code: " + result);
+            }
+
+            Debug.Log("[LibUSB] initialized successfully.");
+        }
+
+        // Return a list of LibUSBDevice objects
+        public List<LibUSBDevice> GetDeviceList()
+        {
+            var devices = new List<LibUSBDevice>();
+
+            int result = libusb_get_device_list(_context, ref _deviceList);
+            if (result < 0)
+            {
+                Debug.Log($"[LibUSBWrapper] failed to get device list {result}.");
+                return devices;
+            }
+
+            for (int i = 0; i < result; i++)
+            {
+                IntPtr device = Marshal.ReadIntPtr(_deviceList + i * 8);
+
+                // Create the device, and add it to the list.
+                devices.Add(new LibUSBDevice(device));
+            }
+
+            return devices;
+        }
+
+        public void FreeDeviceList()
+        {
+            libusb_free_device_list(_deviceList, 1);
+        }
+
+        public void Dispose()
+        {
+            Debug.Log("[LibUSB] Dispose");
+            libusb_exit(_context);
+        }
+    }
+
+    public class LibUSBDevice : IDisposable
+    {
+        [DllImport(Global.LIBUSB_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int libusb_claim_interface(IntPtr device_handle, int interface_number);
+
+        [DllImport(Global.LIBUSB_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int libusb_interrupt_transfer(IntPtr device_handle, uint endpoint, byte[] data, int length, out int transferred, int timeout);
+
+        [DllImport(Global.LIBUSB_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int libusb_release_interface(IntPtr device_handle, int interface_number);
+
+        [DllImport(Global.LIBUSB_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int libusb_open(IntPtr dev, ref IntPtr handle);
+
+        [DllImport(Global.LIBUSB_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
+        private static extern void libusb_close(IntPtr handle);
+
+        [DllImport(Global.LIBUSB_LIBRARY, CallingConvention = CallingConvention.Cdecl)]
+        private static extern int libusb_get_device_descriptor(IntPtr dev, ref LibUSBDeviceDescriptor desc);
+
+        // Define the device descriptor structure
+        [StructLayout(LayoutKind.Sequential)]
+        private struct LibUSBDeviceDescriptor
+        {
+            public byte bLength;
+            public byte bDescriptorType;
+            public short bcdUSB;
+            public byte bDeviceClass;
+            public byte bDeviceSubClass;
+            public byte bDeviceProtocol;
+            public byte bMaxPacketSize0;
+            public ushort idVendor;
+            public ushort idProduct;
+            public ushort bcdDevice;
+            public byte iManufacturer;
+            public byte iProduct;
+            public byte iSerialNumber;
+            public byte bNumConfigurations;
+        }
+
+        private readonly IntPtr _devicePointer;
+        private readonly LibUSBDeviceDescriptor _descriptor;
+        private IntPtr _handle = IntPtr.Zero;
+
+        public LibUSBDevice(IntPtr devicePointer)
+        {
+            // Populate the device descriptor.
+            var result = libusb_get_device_descriptor(devicePointer, ref _descriptor);
+            if (result != 0)
+            {
+                Debug.Log("Failed to populate device descriptor.");
+            }
+
+            _devicePointer = devicePointer;
+        }
+
+        // Get the Vendor ID
+        public ushort VendorID => _descriptor.idVendor;
+
+        // Get the Product ID
+        public ushort ProductID => _descriptor.idProduct;
+
+        // Open the device
+        public void Open()
+        {
+            int result = libusb_open(_devicePointer, ref _handle);
+            if (result != 0)
+            {
+                Debug.Log("Failed to open device.");
+            }
+        }
+
+        public void ClaimInterface(int interfaceIndex)
+        {
+            int claimResult = libusb_claim_interface(_handle, interfaceIndex);
+            if (claimResult < 0)
+            {
+                Debug.Log("Failed to claim interface, error code: " + claimResult);
+            }
+        }
+
+        public void ReleaseInterface(int interfaceIndex)
+        {
+            int releaseResult = libusb_release_interface(_handle, interfaceIndex);
+            if (releaseResult < 0)
+            {
+                Debug.Log("[LibUSB] Failed to release interface, error code: " + releaseResult);
+            }
+        }
+
+        public void InterruptTranferOut(uint endpoint, byte[] payload)
+        {
+            int transferred;
+
+            int transferResult = libusb_interrupt_transfer(_handle, endpoint, payload, payload.Length, out transferred, 1000);
+
+            if (transferResult < 0)
+            {
+                Debug.Log("Failed to send payload, error code: " + transferResult);
+                return;
+            }
+
+            Debug.Log("sent payload");
+        }
+
+        public void ListenForDeviceInterrupts(uint endpoint, int bufferSize, Action<byte[]> callback, CancellationToken cancellationToken)
+        {
+            byte[] interruptData = new byte[bufferSize];
+            
+            Task.Run(() =>
+            {
+                while (!cancellationToken.IsCancellationRequested)
+                {
+                    int transferred;
+                    int result = libusb_interrupt_transfer(_handle, endpoint + 128, interruptData, bufferSize, out transferred, 0);
+
+                    if (result < 0)
+                    {
+                        Debug.Log($"Error during interrupt transfer: {result}");
+                        return;
+                    }
+
+                    if (transferred > 0)
+                    {
+                        callback(interruptData);
+                    }
+                }
+            }, cancellationToken);
+        }
+
+        public void Dispose() {
+            Debug.Log("[LibUSBDevice] dispose");
+
+            libusb_close(_handle);
+        }
+    }
+}

--- a/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/LibUSBWrapper.cs.meta
+++ b/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/LibUSBWrapper.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e306b79064bce4054a78b85343d9c536
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/USBBackend.cs
+++ b/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/USBBackend.cs
@@ -1,65 +1,58 @@
 using System;
 using System.Threading;
-using System.Threading.Tasks;
-using System.Runtime.InteropServices;
 using System.Collections.Generic;
-using UnityEngine;
-using LibUSBWrapper;
+using HIDrogen.Imports;
 
 namespace HIDrogen.Backend
 {
     internal class USBBackend : IDisposable
     {
-        private LibUSBWrapper.LibUSB _libusb;
+        private LibUSB _libusb;
 
         private List<IDisposable> m_Devices = new List<IDisposable>();
 
-        private CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+        private Thread m_watchThread;
+        private EventWaitHandle m_ThreadStop = new EventWaitHandle(false, EventResetMode.ManualReset);
 
         public USBBackend()
         {
-            Debug.Log("[USBBackend] init");
+            Logging.Verbose("Initializing USBBackend");
 
             try
             {
-                _libusb = new LibUSBWrapper.LibUSB();
+                _libusb = new LibUSB();
             }
             catch (Exception ex) {
-                Debug.Log($"Failed to init libusb. {ex}");
+                Logging.Exception("Failed to initialize libusb.", ex);
                 return;
             }
 
-            // Create a task to watch 
-            var token = cancellationTokenSource.Token;
+            // Create a new thread
+            Thread m_watchThread = new Thread(WatchForDevices);
 
-            Task.Run(() =>
-            {
-                while (!token.IsCancellationRequested)
-                {
-                    GetDevices();
-                    Thread.Sleep(1000);
-                }
-            }, token);
+            // Start the thread
+            m_watchThread.Start();
         }
 
-        void GetDevices()
+        private void WatchForDevices()
         {
             // We're only searching for one device at the moment.
-            if (m_Devices.Count == 1) return;
-
-            var devices = _libusb.GetDeviceList();
-
-            Debug.Log($"found {devices.Count} devices");
-
-            foreach (var device in devices)
+            while (m_Devices.Count != 1 && !m_ThreadStop.WaitOne(1000))
             {
-                InspectDevice(device);
-            }
+                var devices = _libusb.GetDeviceList();
 
-            _libusb.FreeDeviceList();
+                Logging.Verbose($"found {devices.Count} USB devices");
+
+                foreach (var device in devices)
+                {
+                    InspectDevice(device);
+                }
+
+                _libusb.FreeDeviceList();
+            }
         }
 
-        private void InspectDevice(LibUSBWrapper.LibUSBDevice device) {
+        private void InspectDevice(LibUSBDevice device) {
 
             // Microsoft USB Device
             if (device.VendorID == 0x045e)
@@ -67,7 +60,7 @@ namespace HIDrogen.Backend
                 // Known Product IDs for this dongle.
                 if (device.ProductID == 0x0291 || device.ProductID == 0x02a9 || device.ProductID == 0x0719)
                 {
-                    Debug.Log("Found X360Receiver");
+                    Logging.Verbose("Found X360Receiver");
                     device.Open();
                     m_Devices.Add(new X360Receiver(device));
                 }
@@ -76,10 +69,13 @@ namespace HIDrogen.Backend
 
         public void Dispose()
         {
-            Debug.Log("[USBBackend] disposing");
-
             // Stop watching for devices.
-            cancellationTokenSource.Cancel();
+            m_ThreadStop?.Set();
+            m_watchThread?.Join();
+            m_watchThread = null;
+
+            m_ThreadStop?.Dispose();
+            m_ThreadStop = null;
 
             foreach (var device in m_Devices)
                 device.Dispose();

--- a/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/USBBackend.cs
+++ b/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/USBBackend.cs
@@ -41,8 +41,6 @@ namespace HIDrogen.Backend
             {
                 var devices = _libusb.GetDeviceList();
 
-                Logging.Verbose($"found {devices.Count} USB devices");
-
                 // Inspect each device that hasn't been ignored or connected already.
                 foreach (var device in devices)
                     if (!ignoredDeviceIDs.Contains(device.Id) && !m_Devices.ContainsKey(device.Id))

--- a/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/USBBackend.cs
+++ b/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/USBBackend.cs
@@ -1,0 +1,90 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Runtime.InteropServices;
+using System.Collections.Generic;
+using UnityEngine;
+using LibUSBWrapper;
+
+namespace HIDrogen.Backend
+{
+    internal class USBBackend : IDisposable
+    {
+        private LibUSBWrapper.LibUSB _libusb;
+
+        private List<IDisposable> m_Devices = new List<IDisposable>();
+
+        private CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+
+        public USBBackend()
+        {
+            Debug.Log("[USBBackend] init");
+
+            try
+            {
+                _libusb = new LibUSBWrapper.LibUSB();
+            }
+            catch (Exception ex) {
+                Debug.Log($"Failed to init libusb. {ex}");
+                return;
+            }
+
+            // Create a task to watch 
+            var token = cancellationTokenSource.Token;
+
+            Task.Run(() =>
+            {
+                while (!token.IsCancellationRequested)
+                {
+                    GetDevices();
+                    Thread.Sleep(1000);
+                }
+            }, token);
+        }
+
+        void GetDevices()
+        {
+            // We're only searching for one device at the moment.
+            if (m_Devices.Count == 1) return;
+
+            var devices = _libusb.GetDeviceList();
+
+            Debug.Log($"found {devices.Count} devices");
+
+            foreach (var device in devices)
+            {
+                InspectDevice(device);
+            }
+
+            _libusb.FreeDeviceList();
+        }
+
+        private void InspectDevice(LibUSBWrapper.LibUSBDevice device) {
+
+            // Microsoft USB Device
+            if (device.VendorID == 0x045e)
+            {
+                // Known Product IDs for this dongle.
+                if (device.ProductID == 0x0291 || device.ProductID == 0x02a9 || device.ProductID == 0x0719)
+                {
+                    Debug.Log("Found X360Receiver");
+                    device.Open();
+                    m_Devices.Add(new X360Receiver(device));
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            Debug.Log("[USBBackend] disposing");
+
+            // Stop watching for devices.
+            cancellationTokenSource.Cancel();
+
+            foreach (var device in m_Devices)
+                device.Dispose();
+
+            _libusb.Dispose();
+        }
+    }
+}

--- a/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/USBBackend.cs.meta
+++ b/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/USBBackend.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a5dbcd583b0e841f8908706dd34a0900
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/X360Controller.cs
+++ b/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/X360Controller.cs
@@ -121,8 +121,8 @@ namespace HIDrogen.Backend
         public XInputVibration vibration;
     }
 
-	internal class X360Controller : IDisposable
-	{
+    internal class X360Controller : IDisposable
+    {
         private readonly X360Receiver m_Backend;
         public const string InterfaceName = "XInput";
 
@@ -153,7 +153,7 @@ namespace HIDrogen.Backend
             // Claim the control interface.
             receiver.ClaimInterface(interfaceIndex);
 
-            // Create a new thread to wait and handle to input.
+            // Create a new thread to wait for and handle input.
             m_interruptThread = new Thread(WaitForInterrupt);
             m_interruptThread.Start();
 
@@ -306,7 +306,7 @@ namespace HIDrogen.Backend
             _receiver.InterruptTranferOut(controlEndpoint, payload);
         }
 
-		public void Dispose()
+        public void Dispose()
         {
             if (connected)
             {
@@ -316,7 +316,7 @@ namespace HIDrogen.Backend
 
             _receiver.ReleaseInterface(interfaceIndex);
             connected = false;
-		}
+        }
 
         public void HIDUpdate(byte[] bytes)
         {

--- a/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/X360Controller.cs
+++ b/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/X360Controller.cs
@@ -308,14 +308,13 @@ namespace HIDrogen.Backend
 
 		public void Dispose()
         {
-            _receiver.ReleaseInterface(interfaceIndex);
-
             if (connected)
             {
                 PowerDown();
                 m_Backend.QueueDeviceRemove(device);
             }
 
+            _receiver.ReleaseInterface(interfaceIndex);
             connected = false;
 		}
 

--- a/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/X360Controller.cs
+++ b/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/X360Controller.cs
@@ -196,8 +196,11 @@ namespace HIDrogen.Backend
 
                     case 0x000f: {
                         // The link control packet.
-                        AddDevice(payload);
-                        connected = true;
+                        if (!connected)
+                        {
+                            AddDevice(payload);
+                            connected = true;
+                        }
                         break;
                     }
 

--- a/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/X360Controller.cs
+++ b/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/X360Controller.cs
@@ -1,0 +1,320 @@
+using System;
+using System.Threading;
+using HIDrogen.LowLevel;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.Layouts;
+using UnityEngine.InputSystem.LowLevel;
+using UnityEngine.InputSystem.Utilities;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Buffers.Binary;
+using LibUSBWrapper;
+
+namespace HIDrogen.Backend
+{
+    [Serializable]
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    internal struct XInputVibration
+    {
+        public ushort leftMotor;
+        public ushort rightMotor;
+    }
+
+    internal enum XInputDeviceType : byte
+    {
+        Gamepad = 1,
+    }
+
+    internal enum XInputDeviceSubType : byte
+    {
+        Unknown = 0,
+        Gamepad = 1,
+        Wheel = 2,
+        ArcadeStick = 3,
+        FlightStick = 4,
+        DancePad = 5,
+        Guitar = 6,
+        GuitarAlternate = 7,
+        DrumKit = 8,
+        StageKit = 9,
+        GuitarBass = 11,
+        ProKeyboard = 15,
+        ArcadePad = 19,
+        DJTurntable = 23,
+        ProGuitar = 25,
+    }
+
+    [Flags]
+    internal enum XInputDeviceFlags : ushort
+    {
+        ForceFeedback = 0x01,
+        Wireless = 0x02,
+        Voice = 0x04,
+        PluginModules = 0x08,
+        NoNavigation = 0x10,
+    }
+
+    [Flags]
+    internal enum XInputButton : ushort
+    {
+        DpadUp = 0x0001,
+        DpadDown = 0x0002,
+        DpadLeft = 0x0004,
+        DpadRight = 0x0008,
+        Start = 0x0010,
+        Back = 0x0020,
+        LeftThumb = 0x0040,
+        RightThumb = 0x0080,
+        LeftShoulder = 0x0100,
+        RightShoulder = 0x0200,
+        Guide = 0x0400,
+        A = 0x1000,
+        B = 0x2000,
+        X = 0x4000,
+        Y = 0x8000
+    }
+
+    internal enum LEDState : uint
+    {
+        LED_OFF = 0,
+        LED_BLINK = 1,
+        LED_1_SWITCH_BLINK = 2,
+        LED_2_SWITCH_BLINK = 3,
+        LED_3_SWITCH_BLINK = 4,
+        LED_4_SWITCH_BLINK = 5,
+        LED_1 = 6,
+        LED_2 = 7,
+        LED_3 = 8,
+        LED_4 = 9,
+        LED_CYCLE = 10,
+        LED_FAST_BLINK = 11,
+        LED_SLOW_BLINK = 12,
+        LED_FLIPFLOP = 13,
+        LED_ALLBLINK = 14,
+    }
+
+    [Serializable]
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    internal struct XInputGamepad : IInputStateTypeInfo
+    {
+        public static readonly FourCC Format = new FourCC('X', 'I', 'N', 'P');
+        public FourCC format => Format;
+
+        public XInputButton buttons;
+        public byte leftTrigger;
+        public byte rightTrigger;
+        public short leftStickX;
+        public short leftStickY;
+        public short rightStickX;
+        public short rightStickY;
+    }
+
+    [Serializable]
+    internal struct XInputDescriptionCapabilities
+    {
+        public uint userIndex;
+        public XInputDeviceType type;
+        public XInputDeviceSubType subType;
+        public XInputDeviceFlags flags;
+        public XInputGamepad gamepad;
+        public XInputVibration vibration;
+    }
+
+	internal class X360Controller : IDisposable
+	{
+        private readonly X360Receiver m_Backend;
+        public const string InterfaceName = "XInput";
+        public static readonly FourCC InputFormat = new FourCC('X', 'I', 'N', 'P');
+
+        private LibUSBDevice receiver;
+        public InputDevice device { get; set; }
+
+        public uint userIndex { get; }
+        private bool connected = false;
+        private int interfaceIndex;
+        private uint controlEndpoint;
+
+        private CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+
+        public X360Controller(X360Receiver backend, LibUSBDevice receiver, uint userIndex)
+        {
+            m_Backend = backend;
+            this.receiver = receiver;
+            this.userIndex = userIndex;
+
+            // The receiver has 8 endpoints,
+            // E1: P1 Controller, E2: P1 Voice,
+            // E3: P2 Controller, E4: P2 Voice,
+            // E5: P3 Controller, E6: P3 Voice,
+            // E7: P4 Controller, E8: P4 Voice,
+            // for a total of 4 players. 
+            interfaceIndex = (int)userIndex * 2;
+            controlEndpoint = (uint)interfaceIndex + 1;
+
+            // Claim the control interface.
+            receiver.ClaimInterface(interfaceIndex);
+
+            // Listen for 32 byte interrupts on the control endpoint.
+            receiver.ListenForDeviceInterrupts(controlEndpoint, 32, (payload) =>
+            {
+                // Loop over the first two bytes of the payload.
+                switch ((payload[0] << 8) | payload[1]) {
+                    case 0x0001: { 
+                        // Device state update.
+                        HIDUpdate(payload);
+                        break;
+                    }
+
+                    case 0x000f: {
+                        // The link control packet.
+                        AddDevice(payload);
+                        connected = true;
+                        break;
+                    }
+
+                    case 0x0800: {
+                        // Controller disconnection
+                        if (connected)
+                        {
+                            m_Backend.QueueDeviceRemove(device);
+                            connected = false;
+                        }
+                        break;
+                    }
+
+                    default: {
+                        // Many more report types exist that might be useful
+                        // to handle (such as battery events)
+                        // but we'll ignore all of the them for now.
+                        break;
+                    }
+                }
+            }, cancellationTokenSource.Token);
+
+            // Controllers will automatically send a link control packet
+            // when first connected to the receiver. We will now request another
+            // in case this class was not listening when that happened.
+            SendInquiry();
+        }
+
+        public void AddDevice(byte[] bytes)
+        {
+            // For some reason, my TBRB drumkit and TBRB Hofner Bass
+            // report subType values 0x80 higher than expected.
+            // TODO: figure out why
+            var subType = (XInputDeviceSubType)(bytes[25] & 0x7F);
+
+            var description = new InputDeviceDescription()
+            {
+                interfaceName = InterfaceName,
+                capabilities = JsonUtility.ToJson(new XInputDescriptionCapabilities()
+                {
+                    userIndex = userIndex,
+                    type = XInputDeviceType.Gamepad,
+                    subType = subType,
+                    flags = XInputDeviceFlags.Wireless | XInputDeviceFlags.Voice,
+                    gamepad = new XInputGamepad(),
+                    vibration = new XInputVibration()
+                }),
+            };
+
+            Debug.Log(description);
+
+            m_Backend.QueueDeviceAdd(description, new USBQueueContext()
+            {
+                userIndex = userIndex
+            });
+
+            switch (userIndex)
+            {
+                case 0: {
+                    SetLED(LEDState.LED_1);
+                    break;
+                }
+                case 1: {
+                    SetLED(LEDState.LED_2);
+                    break;
+                }
+                case 2: {
+                    SetLED(LEDState.LED_3);
+                    break;
+                }
+                case 3: {
+                    SetLED(LEDState.LED_4);
+                    break;
+                }
+            }
+        }
+
+        public void SendInquiry()
+        {
+            var payload = new byte[12];
+            payload[0] = 8;
+            payload[2] = 0x0f;
+            payload[3] = 0xc0;
+
+            receiver.InterruptTranferOut(controlEndpoint, payload);
+        }
+
+        public void PowerDown()
+        {
+            var payload = new byte[12];
+            payload[2] = 8;
+            payload[3] = 0xc0;
+            receiver.InterruptTranferOut(controlEndpoint, payload);
+        }
+
+        public void SetLED(LEDState ledState)
+        {
+            var payload = new byte[12];
+            payload[2] = 8;
+            payload[3] = (byte)((uint)ledState + 0x40);
+            receiver.InterruptTranferOut(controlEndpoint, payload);
+        }
+
+        public void SetRumble(byte highFreq, byte lowFreq)
+        {
+            var payload = new byte[12];
+            payload[1] = 1;
+            payload[2] = 0x0f;
+            payload[3] = 0xc0;
+            payload[5] = highFreq;
+            payload[6] = lowFreq;
+
+            receiver.InterruptTranferOut(controlEndpoint, payload);
+        }
+
+		public void Dispose()
+        {
+            Debug.Log("[X360Controller] disposing");
+            cancellationTokenSource.Cancel();
+            receiver.ReleaseInterface(interfaceIndex);
+
+            if (connected)
+            {
+                PowerDown();
+                m_Backend.QueueDeviceRemove(device);
+            }
+
+            connected = false;
+		}
+
+        public void HIDUpdate(byte[] bytes)
+        {
+            XInputGamepad gamepadState;
+            gamepadState.buttons = (XInputButton)BitConverter.ToUInt16(bytes, 6);
+            gamepadState.leftTrigger = bytes[8]; 
+            gamepadState.rightTrigger = bytes[9]; 
+            gamepadState.leftStickX = (short)BitConverter.ToInt16(bytes, 10);
+            gamepadState.leftStickY = (short)BitConverter.ToInt16(bytes, 12);
+            gamepadState.rightStickX = (short)BitConverter.ToInt16(bytes, 14);
+            gamepadState.rightStickY = (short)BitConverter.ToInt16(bytes, 16);
+
+            // TODO: find a place for Ext bytes: 18,19,20,21,22,23
+
+            m_Backend.QueueStateEvent(device, ref gamepadState);
+        }
+    }
+}

--- a/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/X360Controller.cs.meta
+++ b/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/X360Controller.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bbe6478794b624e819392a95bb144a47
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/X360Receiver.cs
+++ b/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/X360Receiver.cs
@@ -1,0 +1,110 @@
+using System;
+using HIDrogen.LowLevel;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.Layouts;
+using UnityEngine.InputSystem.LowLevel;
+using UnityEngine.InputSystem.Utilities;
+using System.Runtime.InteropServices;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Buffers.Binary;
+using LibUSBWrapper;
+
+// The Xbox360 Wireless Receiver is a 'Vendor Specific' (0xFF) class device,
+// so will not be recognised by unity natively.
+
+namespace HIDrogen.Backend
+{
+    internal class USBQueueContext : IDisposable
+    {
+        public uint userIndex;
+
+        public void Dispose() {}
+    }
+
+    internal class X360Receiver : CustomInputBackend<X360Controller>
+    {
+        // Each wireless receiver supports up to 4 controllers.
+        private readonly X360Controller[] m_Controllers = new X360Controller[4];
+
+        private LibUSBWrapper.LibUSBDevice _usbDevice;
+
+        public X360Receiver(LibUSBWrapper.LibUSBDevice usbDevice)
+        {
+            Debug.Log("[X360Receiver] init");
+
+            for (uint i = 0; i < 4; i++) 
+            {
+                m_Controllers[i] = new X360Controller(this, usbDevice, i);
+            }
+
+            _usbDevice = usbDevice;
+        }
+
+        protected override void OnDispose()
+        {
+            Debug.Log("[X360Receiver] OnDispose");
+
+            for (uint i = 0; i < 4; i++) 
+            {
+                m_Controllers[i]?.Dispose();
+                m_Controllers[i] = null;
+            }
+
+            _usbDevice.Dispose();
+        }
+
+        public void Dispose()
+        {
+            OnDispose();
+        }
+
+        protected override X360Controller OnDeviceAdded(InputDevice device, IDisposable _context)
+        {
+            Debug.Log("[X360Receiver] OnDeviceAdded");
+
+            var context = (USBQueueContext)_context;
+
+            m_Controllers[context.userIndex].device = device;
+
+            return m_Controllers[context.userIndex];
+        }
+
+        protected override void OnDeviceRemoved(X360Controller device)
+        {
+            Debug.Log("[X360Receiver] OnDeviceRemoved");
+        }
+
+        protected override unsafe long? OnDeviceCommand(X360Controller device, InputDeviceCommand* command)
+        {
+            Debug.Log($"[X360Receiver] OnDeviceCommand {command->type}");
+
+            // System commands
+            // if (command->type == EnableDeviceCommand.Type)
+            //     return Enable(command);
+            // if (command->type == DisableDeviceCommand.Type)
+            //     return Disable(command);
+            // if (command->type == QueryEnabledStateCommand.Type)
+            //     return IsEnabled(command);
+            // if (command->type == RequestSyncCommand.Type)
+            //     return SyncState(command);
+            // if (command->type == RequestResetCommand.Type)
+            //     return ResetState(command);
+            // if (command->type == QueryCanRunInBackground.Type)
+            //     return CanRunInBackground(command);
+
+            // TODO: Untested
+            if (command->type == DualMotorRumbleCommand.Type)
+            {
+                var cmd = (DualMotorRumbleCommand*)command;
+                var lowFreq = BitConverter.GetBytes(cmd->lowFrequencyMotorSpeed)[0];
+                var highFreq = BitConverter.GetBytes(cmd->highFrequencyMotorSpeed)[0];
+                device.SetRumble(highFreq, lowFreq);
+                return null;
+            }
+
+            return null;
+        }
+    }
+}

--- a/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/X360Receiver.cs
+++ b/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/X360Receiver.cs
@@ -29,6 +29,8 @@ namespace HIDrogen.Backend
         {
             Logging.Verbose("[X360Receiver] init");
 
+            usbDevice.Open();
+
             for (uint i = 0; i < 4; i++) 
             {
                 m_Controllers[i] = new X360Controller(this, usbDevice, i);

--- a/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/X360Receiver.cs.meta
+++ b/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/X360Receiver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 759f3c7f00e2349bab7586ab34d49d7e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/com.thenathannator.hidrogen/HIDrogen/HIDrogen.asmdef
+++ b/Packages/com.thenathannator.hidrogen/HIDrogen/HIDrogen.asmdef
@@ -1,11 +1,13 @@
 {
     "name": "HIDrogen",
+    "rootNamespace": "",
     "references": [
         "Unity.InputSystem"
     ],
     "includePlatforms": [
         "Editor",
         "LinuxStandalone64",
+        "macOSStandalone",
         "WindowsStandalone64"
     ],
     "excludePlatforms": [],

--- a/Packages/com.thenathannator.hidrogen/HIDrogen/Initialization.Linux.cs
+++ b/Packages/com.thenathannator.hidrogen/HIDrogen/Initialization.Linux.cs
@@ -6,15 +6,18 @@ namespace HIDrogen
     internal static partial class Initialization
     {
         private static HidApiBackend s_HidApiBackend;
+        private static USBBackend s_USBBackend;
 
         static partial void PlatformInitialize()
         {
+            s_USBBackend = new USBBackend();
             s_HidApiBackend = new HidApiBackend();
             LinuxShim.Initialize();
         }
 
         static partial void PlatformUninitialize()
         {
+            s_USBBackend?.Dispose();
             s_HidApiBackend?.Dispose();
             LinuxShim.Uninitialize();
         }

--- a/Packages/com.thenathannator.hidrogen/HIDrogen/Initialization.MacOS.cs
+++ b/Packages/com.thenathannator.hidrogen/HIDrogen/Initialization.MacOS.cs
@@ -1,8 +1,5 @@
 #if UNITY_STANDALONE_OSX
 using HIDrogen.Backend;
-using System.Collections;
-using System.Collections.Generic;
-using UnityEngine;
 
 namespace HIDrogen
 {

--- a/Packages/com.thenathannator.hidrogen/HIDrogen/Initialization.MacOS.cs
+++ b/Packages/com.thenathannator.hidrogen/HIDrogen/Initialization.MacOS.cs
@@ -1,0 +1,24 @@
+#if UNITY_STANDALONE_OSX
+using HIDrogen.Backend;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace HIDrogen
+{
+    internal static partial class Initialization
+    {
+        private static USBBackend s_USBBackend;
+
+        static partial void PlatformInitialize()
+        {
+            s_USBBackend = new USBBackend();
+        }
+
+        static partial void PlatformUninitialize()
+        {
+            s_USBBackend?.Dispose();
+        }
+    }
+}
+#endif

--- a/Packages/com.thenathannator.hidrogen/HIDrogen/Initialization.MacOS.cs.meta
+++ b/Packages/com.thenathannator.hidrogen/HIDrogen/Initialization.MacOS.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8255ce37463aa47d5a3ecc62bcb2becf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Hi @TheNathannator 👋 

I’m now at the stage where I have Xbox 360 instruments working well in YARG on macOS. 🎉 

To do so, I've needed to build libusb and add the `.dylib` (or presumably `.dll`/`.so`) to `Assets/Plugins`. I've also made [these changes](https://github.com/TheNathannator/PlasticBand-Unity/pull/12) to PlasticBand-Unity, so it is able to recognise XInput devices on non-windows platforms.

I'm still extremely new to both C# and Unity InputSystem, so I would really appreciate any suggestions you can make to this. Hopefully it can land in YARG soon!

Thank you for all of your help and amazing documentation, it’s been a huge help in getting this far.

Resolves #5 