### PR TITLE
[X360Controller] bugfix for missed inputs

### DIFF
--- a/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/X360WirelessController.cs
+++ b/Packages/com.thenathannator.hidrogen/HIDrogen/Backends/USB/X360WirelessController.cs
@@ -236,7 +236,7 @@ namespace HIDrogen.Backend
             const int retryThreshold = 3;
             int errorCount = 0;
 
-            while (!m_ThreadStop.WaitOne(1))
+            while (!m_ThreadStop.WaitOne(0))
             {
                 // Service state timers
                 switch (m_ConnectionState)
@@ -305,7 +305,7 @@ namespace HIDrogen.Backend
                 }
 
                 // Read incoming reports
-                var result = libusb_interrupt_transfer(m_Handle, m_InEndpoint, payload, out int actualLength, 5);
+                var result = libusb_interrupt_transfer(m_Handle, m_InEndpoint, payload, out int actualLength, 100);
                 switch (result)
                 {
                     case libusb_error.SUCCESS:


### PR DESCRIPTION
This PR:

- Removes `m_ThreadStop.WaitOne(1)`, as it feels redundant having a second wait within this thread, and I believe this is the cause of the missed inputs.
- Increases the timeout of `libusb_interrupt_transfer`, as having this at 5ms was the cause of poor performance during my testing on macOS and linux. The only time this delay is actually encountered is when disposing, so it shouldn't be a problem to increase it.

Thanks @TheNathannator, you are welcome to suggest or change anything here!