### PR TITLE
Fix double free crash on Linux when getting device parent

### DIFF
--- a/Packages/com.thenathannator.hidrogen/HIDrogen/Imports/Linux/udev/udev.cs
+++ b/Packages/com.thenathannator.hidrogen/HIDrogen/Imports/Linux/udev/udev.cs
@@ -138,20 +138,14 @@ namespace HIDrogen.Imports.Linux
 
     internal class udev_device : UdevHandle
     {
-        private readonly bool _ownsHandle;
-
         internal udev_device(Udev udev, IntPtr handle, bool ownsHandle)
             : base(udev, handle, ownsHandle)
         {
-            _ownsHandle = ownsHandle;
         }
 
         protected override bool ReleaseHandle()
         {
-            if (_ownsHandle)
-            {
-                m_udev.device_unref(handle);
-            }
+            m_udev.device_unref(handle);
             return true;
         }
 
@@ -186,6 +180,11 @@ namespace HIDrogen.Imports.Linux
 
         [UnmanagedFunctionPointer(CallingConvention.Winapi)]
         private delegate IntPtr _udev_unref(
+            IntPtr handle
+        );
+
+        [UnmanagedFunctionPointer(CallingConvention.Winapi)]
+        private delegate IntPtr _udev_ref(
             IntPtr handle
         );
         #endregion
@@ -313,7 +312,7 @@ namespace HIDrogen.Imports.Linux
         private _udev_new m_udev_context_new;
 
         private _udev_unref m_udev_context_unref;
-        private _udev_unref m_udev_device_ref;
+        private _udev_ref m_udev_device_ref;
         private _udev_unref m_udev_device_unref;
         private _udev_unref m_udev_monitor_unref;
         private _udev_unref m_udev_enumerate_unref;
@@ -534,7 +533,7 @@ namespace HIDrogen.Imports.Linux
             if (devPtr == IntPtr.Zero)
                 return null;
 
-            m_udev_device_ref(devPtr);
+            devPtr = m_udev_device_ref(devPtr);
             return new udev_device(this, devPtr, true);
         }
         #endregion


### PR DESCRIPTION
This PR fixes a crash on Linux when connecting Bluetooth controllers

We have to get the parent of the hiddraw device in order to find the input device, to retrieve the version number.  When getting the parent, we grabbed the pointer directly without incrementing the reference count.  However, We wrapped this in a SafeHandle. When that SafeHandle was disposed via the `using`, ReleaseHandle() always called `udev_device_unref()` regardless of what we passed for `ownsHandle`.

**Fix**
Use `udev_device_ref` to increase the reference count of the parent udev pointer, which makes it stable, then wrap it in a `udev_device` that SafeHandle owns, so it can remove the ref count on dispose.

**Notes**
* It is unclear why SafeHandle was not respecting the `ownsHandle = False` param.  It shows up in the stack trace here: 

```
#15 0x000000408bd99f in HIDrogen.Imports.Linux.udev_device:ReleaseHandle ()
#16 0x0000004037a541 in System.Runtime.InteropServices.SafeHandle:DangerousReleaseInternal (bool)
#17 0x000000404adc37 in System.Runtime.InteropServices.SafeHandle:InternalDispose ()
#18 0x000000404adb43 in System.Runtime.InteropServices.SafeHandle:Dispose (bool)
#19 0x000000404adb15 in System.Runtime.InteropServices.SafeHandle:Dispose ()
#20 0x000000408c4a02 in HIDrogen.Backend.HidApiBackend:PlatformGetVersionNumber (string,uint16&,bool&)
```

* I am still not totally clear on exactly what the double free is.  It's possible that the SafeHandle was freeing first and then OS second.    The stack trace shows the crash happens during `udev_enumerate_scan_devices` calling `udev_device_unref`

* I am unable to reproduce the original issue, even when forcing a call to get parent. It seems this only occurs with some Bluetooth devices?